### PR TITLE
Fixed the error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ venv.bak/
 
 build/
 icxcli.egg-info/
-Tests/test_keystore.txt
+tests/test_keystore.txt
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.0.3] - June 25, 2018
+### Added
+* Added the error when amount and fee user put is not integer values. 
+
+### Changed
+N/A
+
+### Removed
+N/A
+
+
+
 ## [0.0.2] - March 28, 2018
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ sudo apt install autoconf libtool automake
 
 # Version
 
-* 0.0.2
+* 0.0.3
 
 # Glossary
 
@@ -318,7 +318,7 @@ Transfer the value from  A address to B address with the fee.
 
 * fee : Transfer fee (Unit:loop)
 
-    * **YOU SHOULD CHANGE BOTH THE UNIT OF AMOUNT AND FEE TO LOOP.**
+    * **YOU SHOULD CHANGE BOTH THE UNIT OF AMOUNT AND FEE TO LOOP. You should enter integer values for amount and fee, not floating number.**
         - Unit: loop 
             * Ex) 1 icx = 10<sup>18</sup> loop
      
@@ -345,4 +345,6 @@ Return 0 : Succeed to transfer
 * Return 130: The wallet address is wrong.
 
 * Return 133: The file is not a key store file.
+
+* Return 135: The amount and fee is not integer values. 
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Transfer the value from  A address to B address with the fee.
 
 * fee : Transfer fee (Unit:loop)
 
-    * **YOU SHOULD CHANGE BOTH THE UNIT OF AMOUNT AND FEE TO LOOP, ENTERING INTEGER VALUES FOR AMOUNT AND FEE NOT FLOATING NUMBERS.**
+    * **YOU SHOULD CHANGE BOTH THE UNIT OF AMOUNT AND FEE TO LOOP, ENTERING INTEGER VALUES FOR AMOUNT NOT FLOATING NUMBERS.**
         - Unit: loop 
             * Ex) 1 icx = 10<sup>18</sup> loop
      
@@ -346,5 +346,5 @@ Return 0 : Succeed to transfer
 
 * Return 133: The file is not a key store file.
 
-* Return 135: The amount and fee is not integer values. 
+* Return 135: The amount is not integer values. 
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Transfer the value from  A address to B address with the fee.
 
 * fee : Transfer fee (Unit:loop)
 
-    * **YOU SHOULD CHANGE BOTH THE UNIT OF AMOUNT AND FEE TO LOOP. You should enter integer values for amount and fee, not floating number.**
+    * **YOU SHOULD CHANGE BOTH THE UNIT OF AMOUNT AND FEE TO LOOP, ENTERING INTEGER VALUES FOR AMOUNT AND FEE NOT FLOATING NUMBERS.**
         - Unit: loop 
             * Ex) 1 icx = 10<sup>18</sup> loop
      

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Prerequisite
 Version
 =======
 
--  0.0.2
+-  0.0.3
 
 
 Getting started

--- a/icxcli/__init__.py
+++ b/icxcli/__init__.py
@@ -19,4 +19,4 @@ ICXCLI
 A Universal Command Line Environment for ICON.
 """
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'

--- a/icxcli/cmd/__init__.py
+++ b/icxcli/cmd/__init__.py
@@ -56,7 +56,7 @@ def parse_args():
     parser = argparse.ArgumentParser(prog='icli.py', usage='''
     
     ==============================
-    icli: ICON CLI tool (v 0.0.2)
+    icli: ICON CLI tool (v 0.0.3)
     ==============================
         Normal commands:
             version

--- a/icxcli/cmd/__init__.py
+++ b/icxcli/cmd/__init__.py
@@ -56,7 +56,7 @@ def parse_args():
     parser = argparse.ArgumentParser(prog='icli.py', usage='''
     
     ==============================
-    icli: ICON CLI tool (v 0.0.3)
+    icli: ICON CLI tool (v '''f'{__version__}'''')
     ==============================
         Normal commands:
             version

--- a/icxcli/cmd/wallet.py
+++ b/icxcli/cmd/wallet.py
@@ -17,7 +17,7 @@
 
 from enum import Enum
 from icxcli.icx import wallet, NoEnoughBalanceInWallet, AddressIsWrong, PasswordIsWrong, FilePathIsWrong, \
-    AmountIsInvalid, TransferFeeIsInvalid, FeeIsBiggerThanAmount, NotAKeyStoreFile, AddressIsSame
+    AmountIsInvalid, TransferFeeIsInvalid, FeeIsBiggerThanAmount, NotAKeyStoreFile, AddressIsSame, AmountOrFeeIsNotInteger
 import json
 
 
@@ -34,11 +34,12 @@ class ExitCode(Enum):
     TRANSFER_FEE_IS_INVALID = 128
     TIMESTAMP_IS_NOT_CORRECT = 129
     WALLET_ADDRESS_IS_WRONG = 130
-    NO_PERMISSION_TO_WRITE_FILE = 136
     AMOUNT_IS_INVALID = 131
     DECIMAL_POINT_INVALID = 132
     NOT_A_KEY_STORE_FILE = 133
     WALLET_ADDRESS_IS_SAME = 134
+    AMOUNT_OR_FEE_IS_NOT_INTEGER = 135
+    NO_PERMISSION_TO_WRITE_FILE = 136
 
 
 def create_wallet(password, file_path) -> int:
@@ -178,6 +179,9 @@ def transfer_value_with_the_fee(password, fee, to, amount, file_path, url) -> in
     except AddressIsSame:
         print("Wallet address to transfer must be different from Wallet address to deposit.")
         return ExitCode.WALLET_ADDRESS_IS_SAME.value
+    except AmountOrFeeIsNotInteger:
+        print("Amount and fee should be integer and loop unit, not icx")
+        return ExitCode.AMOUNT_OR_FEE_IS_NOT_INTEGER.value
 
 
 def store_wallet(file_path, json_string) -> int:

--- a/icxcli/cmd/wallet.py
+++ b/icxcli/cmd/wallet.py
@@ -170,7 +170,7 @@ def transfer_value_with_the_fee(password, fee, to, amount, file_path, url) -> in
         print("Transaction Fee is invalid. The fee should be 10000000000000000.")
         return ExitCode.TRANSFER_FEE_IS_INVALID.value
     except FeeIsBiggerThanAmount:
-        print("Fee is bigger than transaction amount. Ple∂ase check your fee again.")
+        print("Fee is bigger than transaction amount. Please check your fee again.")
         return ExitCode.TRANSFER_FEE_IS_INVALID.value
     except NotAKeyStoreFile:
         print(f"{file_path} is not a Key store File.")

--- a/icxcli/cmd/wallet.py
+++ b/icxcli/cmd/wallet.py
@@ -17,7 +17,7 @@
 
 from enum import Enum
 from icxcli.icx import wallet, NoEnoughBalanceInWallet, AddressIsWrong, PasswordIsWrong, FilePathIsWrong, \
-    AmountIsInvalid, TransferFeeIsInvalid, FeeIsBiggerThanAmount, NotAKeyStoreFile, AddressIsSame, AmountOrFeeIsNotInteger
+    AmountIsInvalid, TransferFeeIsInvalid, FeeIsBiggerThanAmount, NotAKeyStoreFile, AddressIsSame, AmountIsNotInteger
 import json
 
 
@@ -38,7 +38,7 @@ class ExitCode(Enum):
     DECIMAL_POINT_INVALID = 132
     NOT_A_KEY_STORE_FILE = 133
     WALLET_ADDRESS_IS_SAME = 134
-    AMOUNT_OR_FEE_IS_NOT_INTEGER = 135
+    AMOUNT_IS_NOT_INTEGER = 135
     NO_PERMISSION_TO_WRITE_FILE = 136
 
 
@@ -179,9 +179,9 @@ def transfer_value_with_the_fee(password, fee, to, amount, file_path, url) -> in
     except AddressIsSame:
         print("Wallet address to transfer must be different from Wallet address to deposit.")
         return ExitCode.WALLET_ADDRESS_IS_SAME.value
-    except AmountOrFeeIsNotInteger:
-        print("Amount and fee should be integer and loop unit, not icx")
-        return ExitCode.AMOUNT_OR_FEE_IS_NOT_INTEGER.value
+    except AmountIsNotInteger:
+        print("Amount should be integer and loop unit, not icx")
+        return ExitCode.AMOUNT_IS_NOT_INTEGER.value
 
 
 def store_wallet(file_path, json_string) -> int:

--- a/icxcli/icx/__init__.py
+++ b/icxcli/icx/__init__.py
@@ -146,8 +146,8 @@ class AmountIsInvalid(Error):
     pass
 
 
-class AmountOrFeeIsNotInteger(Error):
-    """Exception raised for "Amount or fee is not integer" """
+class AmountIsNotInteger(Error):
+    """Exception raised for "Amount is not integer" """
     pass
 
 

--- a/icxcli/icx/__init__.py
+++ b/icxcli/icx/__init__.py
@@ -146,6 +146,11 @@ class AmountIsInvalid(Error):
     pass
 
 
+class AmountOrFeeIsNotInteger(Error):
+    """Exception raised for "Amount or fee is not integer" """
+    pass
+
+
 class TransferFeeIsInvalid(Error):
     """Exception raised for "Transfer Fee is Invalid." """
     pass

--- a/icxcli/icx/utils.py
+++ b/icxcli/icx/utils.py
@@ -22,7 +22,7 @@ from json import JSONDecodeError
 import eth_keyfile
 import requests
 from icxcli.icx import IcxSigner, NoEnoughBalanceInWallet, AmountIsInvalid, AddressIsWrong, TransferFeeIsInvalid, \
-    FeeIsBiggerThanAmount, NotAKeyStoreFile, AddressIsSame, AmountOrFeeIsNotInteger
+    FeeIsBiggerThanAmount, NotAKeyStoreFile, AddressIsSame, AmountIsNotInteger
 
 
 def validate_password(password) -> bool:
@@ -266,22 +266,21 @@ def check_balance_enough(balance, amount, fee):
 def check_amount_and_fee_is_valid(amount, fee):
 
     def has_floating_point(str_number):
-        str_number = str(str_number)
         if '.' in str_number:
             return True
         else:
             return False
 
-    if has_floating_point(amount) or has_floating_point(fee) or not float(amount).is_integer or not float(fee).is_integer:
-        raise AmountOrFeeIsNotInteger
+    if has_floating_point(amount):
+        raise AmountIsNotInteger
     elif int(amount) <= 0:
         raise AmountIsInvalid
-    elif int(fee) <= 0 or int(fee) != 10000000000000000:
+    elif fee <= 0 or fee != 10000000000000000:
         raise TransferFeeIsInvalid
-    elif int(amount) < int(fee):
+    elif int(amount) < fee:
         raise FeeIsBiggerThanAmount
 
-    return int(amount), int(fee)
+    return int(amount), fee
 
 
 def change_hex_balance_to_decimal_balance(hex_balance, place=18):

--- a/icxcli/icx/wallet/__init__.py
+++ b/icxcli/icx/wallet/__init__.py
@@ -141,10 +141,7 @@ def transfer_value_with_the_fee(password, fee, to, amount, file_path, url):
 
         method = 'icx_sendTransaction'
 
-        amount = int(float(amount))
-        fee = int(float(fee))
-
-        check_amount_and_fee_is_valid(amount, fee)
+        amount, fee = check_amount_and_fee_is_valid(amount, fee)
 
         params = __make_params(user_address, to, amount, fee, method, private_key_bytes)
         payload = create_jsonrpc_request_content(0, method, params)

--- a/icxcli/icx/wallet/__init__.py
+++ b/icxcli/icx/wallet/__init__.py
@@ -129,6 +129,7 @@ def transfer_value_with_the_fee(password, fee, to, amount, file_path, url):
     :return:
     """
     try:
+
         url = f'{url}v2'
         validate_key_store_file(file_path)
         private_key_bytes = __key_from_key_store(file_path, bytes(password, 'utf-8'))

--- a/icxcli/icx/wallet/__init__.py
+++ b/icxcli/icx/wallet/__init__.py
@@ -141,8 +141,8 @@ def transfer_value_with_the_fee(password, fee, to, amount, file_path, url):
 
         method = 'icx_sendTransaction'
 
-        amount = int(amount)
-        fee = int(fee)
+        amount = int(float(amount))
+        fee = int(float(fee))
 
         check_amount_and_fee_is_valid(amount, fee)
 

--- a/tests/test_api_transfer_value.py
+++ b/tests/test_api_transfer_value.py
@@ -63,6 +63,27 @@ class TestAPI(unittest.TestCase):
         except FileNotFoundError:
             self.assertFalse(True)
 
+    def test_transfer_case0_0(self):
+        """Test for transfer_value_with_the_fee function.
+         Case when transfer 0.1(float) value to a wallet.
+        """
+
+        # Given
+        password = "ejfnvm1234*"
+        file_path = os.path.join(TEST_DIR, "test_keystore_for_transfer.txt")
+
+        # When
+        try:
+            ret = bool(wallet.transfer_value_with_the_fee(
+                password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                amount="0.5", file_path=file_path, url=url))
+
+            # Then
+            self.assertEqual(False, ret)
+
+        except AmountIsInvalid:
+            self.assertTrue(True)
+
     def test_transfer_case1(self):
         """Test for transfer_value_with_the_fee function.
         Case when key_store_file_path is wrong.

--- a/tests/test_api_transfer_value.py
+++ b/tests/test_api_transfer_value.py
@@ -3,7 +3,7 @@ import unittest
 
 from icxcli.icx.utils import get_tx_hash, sign
 from icxcli.icx import wallet, FilePathIsWrong, PasswordIsWrong, NoEnoughBalanceInWallet, TransferFeeIsInvalid, \
-    AddressIsWrong, FeeIsBiggerThanAmount, AmountIsInvalid, AddressIsSame
+    AddressIsWrong, FeeIsBiggerThanAmount, AmountIsInvalid, AddressIsSame, AmountOrFeeIsNotInteger
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 url = 'https://testwallet.icon.foundation/api/'
 
@@ -76,13 +76,14 @@ class TestAPI(unittest.TestCase):
         try:
             ret = bool(wallet.transfer_value_with_the_fee(
                 password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
-                amount="0.5", file_path=file_path, url=url))
+                amount="10000000000000000.755", file_path=file_path, url=url))
 
             # Then
             self.assertEqual(False, ret)
 
-        except AmountIsInvalid:
+        except AmountOrFeeIsNotInteger:
             self.assertTrue(True)
+
 
     def test_transfer_case1(self):
         """Test for transfer_value_with_the_fee function.

--- a/tests/test_api_transfer_value.py
+++ b/tests/test_api_transfer_value.py
@@ -1,9 +1,9 @@
 import os
 import unittest
 
-from icxcli.icx.utils import get_tx_hash, sign
+from icxcli.icx.utils import get_tx_hash, sign, check_amount_and_fee_is_valid
 from icxcli.icx import wallet, FilePathIsWrong, PasswordIsWrong, NoEnoughBalanceInWallet, TransferFeeIsInvalid, \
-    AddressIsWrong, FeeIsBiggerThanAmount, AmountIsInvalid, AddressIsSame, AmountOrFeeIsNotInteger
+    AddressIsWrong, FeeIsBiggerThanAmount, AmountIsInvalid, AddressIsSame, AmountIsNotInteger
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 url = 'https://testwallet.icon.foundation/api/'
 
@@ -81,9 +81,8 @@ class TestAPI(unittest.TestCase):
             # Then
             self.assertEqual(False, ret)
 
-        except AmountOrFeeIsNotInteger:
+        except AmountIsNotInteger:
             self.assertTrue(True)
-
 
     def test_transfer_case1(self):
         """Test for transfer_value_with_the_fee function.
@@ -272,6 +271,28 @@ class TestAPI(unittest.TestCase):
             self.assertTrue(True)
         else:
             self.assertTrue(False)
+
+    def test_check_amount_and_fee_is_valid_1(self):
+        """Test for function called check_amount_and_fee_is_valid with floating values."""
+
+        count = 0
+        test_floating_values = ["123.5", "123.11111110", "100000000000000.12340000"]
+
+        for value in test_floating_values:
+            try:
+                check_amount_and_fee_is_valid(value, 10000000000000000)
+            except AmountIsNotInteger:
+                count += 1
+
+        self.assertEqual(count, 3)
+
+    def test_check_amount_and_fee_is_valid_2(self):
+        """Test for function called check_amount_and_fee_is_valid with integer values."""
+
+        test_integer_values = ["100000000000000123444", "12300000333000000000","12345678901234567"]
+
+        for value in test_integer_values:
+            self.assertEqual(check_amount_and_fee_is_valid(value, 10000000000000000), (int(value), 10000000000000000))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
CLI tool raised 'Password is wrong' when the user tried to transfer amount with floating point. Amount value should be an integer. 