### PR TITLE
Cannot handle multiple wrong user input arguments properly. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Transfer the value from  A address to B address with the fee.
 
 * fee : Transfer fee (Unit:loop)
 
-    * **YOU SHOULD CHANGE BOTH THE UNIT OF AMOUNT AND FEE TO LOOP, ENTERING INTEGER VALUES FOR AMOUNT NOT FLOATING NUMBERS.**
+    * **YOU SHOULD CHANGE BOTH THE UNIT OF AMOUNT AND FEE TO LOOP, ENTERING INTEGER VALUES FOR AMOUNT AND FEE NOT FLOATING NUMBERS.**
         - Unit: loop 
             * Ex) 1 icx = 10<sup>18</sup> loop
      

--- a/icxcli/cmd/__init__.py
+++ b/icxcli/cmd/__init__.py
@@ -20,7 +20,7 @@ import argparse
 import os
 
 from icxcli.cmd import wallet
-from icxcli.icx import NonExistKey
+from icxcli.icx import NonExistKey, TransferFeeIsInvalid
 from icxcli.cmd.wallet import ExitCode
 from icxcli import __version__
 
@@ -85,7 +85,7 @@ def parse_args():
     parser.add_argument('-p', dest='password'
                         , help='password')
     parser.add_argument('-f', dest='fee'
-                        , help='transaction fee', type=int, default=10000000000000000)
+                        , help='transaction fee', default="10000000000000000")
     parser.add_argument('-n', dest='network_id'
                         , help='which network', default='testnet')
 
@@ -104,7 +104,6 @@ def call_wallet_method(command, parser):
    """
 
     args = parser.parse_args()
-    url = None
     try:
         url = get_selected_url(args.network_id)
     except NonExistKey:

--- a/icxcli/cmd/wallet.py
+++ b/icxcli/cmd/wallet.py
@@ -150,6 +150,7 @@ def transfer_value_with_the_fee(password, fee, to, amount, file_path, url) -> in
     :return: Predefined exit code
     """
     try:
+
         transfer_result = wallet.transfer_value_with_the_fee(password, fee, to, amount, file_path, url)
         print("Transaction has been completed successfully.")
         return ExitCode.SUCCEED.value

--- a/icxcli/cmd/wallet.py
+++ b/icxcli/cmd/wallet.py
@@ -155,12 +155,12 @@ def transfer_value_with_the_fee(password, fee, to, amount, file_path, url) -> in
         return ExitCode.SUCCEED.value
     except FilePathIsWrong:
         return ExitCode.FILE_PATH_IS_WRONG.value
-    except PasswordIsWrong:
-        print("Password is wrong.")
-        return ExitCode.PASSWORD_IS_WRONG.value
     except AddressIsWrong:
         print("The transaction target address does not have the correct format. please check the address again.")
         return ExitCode.WALLET_ADDRESS_IS_WRONG.value
+    except PasswordIsWrong:
+        print("Password is wrong.")
+        return ExitCode.PASSWORD_IS_WRONG.value
     except NoEnoughBalanceInWallet:
         print("Wallet does not have enough balance.")
         return ExitCode.WALLET_DOES_NOT_HAVE_ENOUGH_BALANCE.value

--- a/icxcli/icx/utils.py
+++ b/icxcli/icx/utils.py
@@ -273,14 +273,16 @@ def check_amount_and_fee_is_valid(amount, fee):
 
     if has_floating_point(amount):
         raise AmountIsNotInteger
+    elif has_floating_point(fee):
+        raise TransferFeeIsInvalid
     elif int(amount) <= 0:
         raise AmountIsInvalid
-    elif fee <= 0 or fee != 10000000000000000:
+    elif int(fee) <= 0 or int(fee) != 10000000000000000:
         raise TransferFeeIsInvalid
-    elif int(amount) < fee:
+    elif int(amount) < int(fee):
         raise FeeIsBiggerThanAmount
 
-    return int(amount), fee
+    return int(amount), int(fee)
 
 
 def change_hex_balance_to_decimal_balance(hex_balance, place=18):

--- a/icxcli/icx/wallet/__init__.py
+++ b/icxcli/icx/wallet/__init__.py
@@ -130,14 +130,13 @@ def transfer_value_with_the_fee(password, fee, to, amount, file_path, url):
     """
     try:
 
+        validate_address(to)
+
         url = f'{url}v2'
         validate_key_store_file(file_path)
         private_key_bytes = __key_from_key_store(file_path, bytes(password, 'utf-8'))
         user_address = get_address_by_privkey(private_key_bytes)
-
         validate_address(user_address)
-        validate_address(to)
-
         validate_address_is_not_same(user_address, to)
 
         method = 'icx_sendTransaction'

--- a/tests/test_api_transfer_value.py
+++ b/tests/test_api_transfer_value.py
@@ -54,7 +54,7 @@ class TestAPI(unittest.TestCase):
         # When
         try:
             ret = bool(wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                password, "10000000000000000", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
                 amount="1000000000000000000", file_path=file_path, url=url))
 
             # Then
@@ -65,7 +65,7 @@ class TestAPI(unittest.TestCase):
 
     def test_transfer_case0_0(self):
         """Test for transfer_value_with_the_fee function.
-         Case when transfer 0.1(float) value to a wallet.
+         Case when transfer amount which is floating value to a wallet.
         """
 
         # Given
@@ -75,13 +75,34 @@ class TestAPI(unittest.TestCase):
         # When
         try:
             ret = bool(wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
-                amount="10000000000000000.755", file_path=file_path, url=url))
+                password, "1000000000000000", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                amount="10000000000000001.2", file_path=file_path, url=url))
 
             # Then
             self.assertEqual(False, ret)
 
         except AmountIsNotInteger:
+            self.assertTrue(True)
+
+    def test_transfer_case0_1(self):
+        """Test for transfer_value_with_the_fee function.
+         Case when transfering amount with fee which is floating value to a wallet.
+        """
+
+        # Given
+        password = "ejfnvm1234*"
+        file_path = os.path.join(TEST_DIR, "test_keystore_for_transfer.txt")
+
+        # When
+        try:
+            ret = bool(wallet.transfer_value_with_the_fee(
+                password, "1000000000000000.0", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                amount="10000000000000001", file_path=file_path, url=url))
+
+            # Then
+            self.assertEqual(False, ret)
+
+        except TransferFeeIsInvalid:
             self.assertTrue(True)
 
     def test_transfer_case1(self):
@@ -94,7 +115,7 @@ class TestAPI(unittest.TestCase):
         # When
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                password, "10000000000000000", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
                 amount="10000000000000000000", file_path='./wrong_path', url=url)
             # Then
 
@@ -113,7 +134,7 @@ class TestAPI(unittest.TestCase):
         # When
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                password, "10000000000000000", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
                 amount="1000000000000000000", file_path=file_path, url=url)
             # Then
 
@@ -132,7 +153,7 @@ class TestAPI(unittest.TestCase):
         # When
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                password, "10000000000000000", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
                 amount="10000000000000000000000000000000000000000000000000", file_path=file_path, url=url)
             # Then
 
@@ -151,7 +172,7 @@ class TestAPI(unittest.TestCase):
         # When
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 100000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                password, "100000000000", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
                 amount="1000000000000000000", file_path=file_path, url=url)
             # Then
 
@@ -171,7 +192,7 @@ class TestAPI(unittest.TestCase):
         # When
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed9",
+                password, "10000000000000000", to="hxa974f512a510299b53c55535c105ed9",
                 amount="1000000000000000000", file_path=file_path, url=url)
             # Then
 
@@ -190,7 +211,7 @@ class TestAPI(unittest.TestCase):
 
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 100000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                password, "100000000000000", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
                 amount="11234440000000000000", file_path=file_path, url=url)
 
         except TransferFeeIsInvalid:
@@ -207,7 +228,7 @@ class TestAPI(unittest.TestCase):
         file_path = os.path.join(TEST_DIR, "test_keystore_for_transfer.txt")
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                password, "10000000000000000", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
                 amount="1000000000000000", file_path=file_path, url=url)
 
         except FeeIsBiggerThanAmount:
@@ -223,7 +244,7 @@ class TestAPI(unittest.TestCase):
         file_path = os.path.join(TEST_DIR, "test_keystore_for_transfer.txt")
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hxa974f512a510299b53c55535c105ed962fd01ee2",
+                password, "10000000000000000", to="hxa974f512a510299b53c55535c105ed962fd01ee2",
                 amount="0", file_path=file_path, url=url)
 
         except AmountIsInvalid:
@@ -241,13 +262,13 @@ class TestAPI(unittest.TestCase):
 
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hx95e12b1f98f9b847175849f51bed5d121e742f6a",
+                password, "10000000000000000", to="hx95e12b1f98f9b847175849f51bed5d121e742f6a",
                 amount="1020000000000000000", file_path=file_path, url=url)
 
             password = "Adas21312**"
             file_path = os.path.join(TEST_DIR, "test_keystore_for_transfer2.txt")
             ret = wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hx66425784bfddb5b430136b38268c3ce1fb68e8c5",
+                password, "10000000000000000", to="hx66425784bfddb5b430136b38268c3ce1fb68e8c5",
                 amount="1000000000000000000", file_path=file_path, url=url)
 
         except AmountIsInvalid:
@@ -264,7 +285,7 @@ class TestAPI(unittest.TestCase):
         file_path = os.path.join(TEST_DIR, "test_keystore_for_transfer.txt")
         try:
             ret = wallet.transfer_value_with_the_fee(
-                password, 10000000000000000, to="hx66425784bfddb5b430136b38268c3ce1fb68e8c5",
+                password, "10000000000000000", to="hx66425784bfddb5b430136b38268c3ce1fb68e8c5",
                 amount="0", file_path=file_path, url=url)
 
         except AddressIsSame:
@@ -280,7 +301,7 @@ class TestAPI(unittest.TestCase):
 
         for value in test_floating_values:
             try:
-                check_amount_and_fee_is_valid(value, 10000000000000000)
+                check_amount_and_fee_is_valid(value, "10000000000000000")
             except AmountIsNotInteger:
                 count += 1
 
@@ -292,7 +313,7 @@ class TestAPI(unittest.TestCase):
         test_integer_values = ["100000000000000123444", "12300000333000000000","12345678901234567"]
 
         for value in test_integer_values:
-            self.assertEqual(check_amount_and_fee_is_valid(value, 10000000000000000), (int(value), 10000000000000000))
+            self.assertEqual(check_amount_and_fee_is_valid(value, "10000000000000000"), (int(value), 10000000000000000))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If a user runs ``` icli transfer``` command with multiple wrong arguments e.g. wrong address, amount and fee with floating number, wrong key file name, and wrong password, then ```ici``` cannot handle these error properly. For example, ```icli``` printed ```Password is wrong``` even wallet address is also wrong. 